### PR TITLE
feat: introduce UUID request tagging for logging

### DIFF
--- a/analysis/src/main/java/org/eclipse/jifa/analysis/AbstractApiExecutor.java
+++ b/analysis/src/main/java/org/eclipse/jifa/analysis/AbstractApiExecutor.java
@@ -77,7 +77,7 @@ public abstract class AbstractApiExecutor<Analyzer> implements ApiExecutor {
     protected AbstractApiExecutor() {
         loadApi();
 
-        executor = ExecutorFactory.newExecutor(this.getClass().getSimpleName() + " Executor");
+        executor = ExecutorFactory.mdcAware(ExecutorFactory.newExecutor(this.getClass().getSimpleName() + " Executor"));
 
         cachedAnalyzer = Caffeine.newBuilder()
                                  .scheduler(Scheduler.systemScheduler())

--- a/common/common.gradle
+++ b/common/common.gradle
@@ -21,4 +21,9 @@ dependencies {
     api 'commons-io:commons-io:2.13.0'
     api 'com.google.guava:guava:30.0-jre'
     api 'com.google.code.gson:gson:2.8.9'
+
+    // SLF4J implementation to support testing MDC functionality
+    // Using Log4j2 which supports MDC and works with SLF4J 2.x
+    testRuntimeOnly 'org.apache.logging.log4j:log4j-core:2.20.0'
+    testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j2-impl:2.20.0'
 }

--- a/common/src/main/java/org/eclipse/jifa/common/util/ExecutorFactory.java
+++ b/common/src/main/java/org/eclipse/jifa/common/util/ExecutorFactory.java
@@ -24,6 +24,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.slf4j.MDC;
+
 /**
  * Executor factory
  */
@@ -120,9 +122,36 @@ public class ExecutorFactory {
 
         EXECUTORS.put(executor, namePrefix);
         return executor;
-
     }
 
+    /**
+     * Wrap an executor with MDC context propagation.
+     *
+     * @param delegate the executor to wrap
+     * @return executor with MDC context propagation
+     */
+    public static Executor mdcAware(Executor delegate) {
+        return command -> {
+            final Map<String, String> contextMap = MDC.getCopyOfContextMap();
+            delegate.execute(() -> {
+                Map<String, String> previous = MDC.getCopyOfContextMap();
+                try {
+                    if (contextMap != null) {
+                        MDC.setContextMap(contextMap);
+                    } else {
+                        MDC.clear();
+                    }
+                    command.run();
+                } finally {
+                    if (previous != null) {
+                        MDC.setContextMap(previous);
+                    } else {
+                        MDC.clear();
+                    }
+                }
+            });
+        };
+    }
     /**
      * Print the statistic of all executors created by this factory
      *

--- a/common/src/test/java/org/eclipse/jifa/common/util/TestExecutorFactory.java
+++ b/common/src/test/java/org/eclipse/jifa/common/util/TestExecutorFactory.java
@@ -12,18 +12,35 @@
  ********************************************************************************/
 package org.eclipse.jifa.common.util;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestExecutorFactory {
+
+    @BeforeEach
+    public void setup() {
+        MDC.clear();
+    }
+
+    @AfterEach
+    public void cleanup() {
+        MDC.clear();
+    }
 
     @Test
     public void test() throws InterruptedException {
@@ -71,5 +88,183 @@ public class TestExecutorFactory {
         assertThrows(IllegalArgumentException.class, () -> ExecutorFactory.newExecutor("prefix", 0, 1));
         assertThrows(IllegalArgumentException.class, () -> ExecutorFactory.newScheduledExecutorService(null, 1));
         assertThrows(IllegalArgumentException.class, () -> ExecutorFactory.newScheduledExecutorService("prefix", 0));
+    }
+
+    // MDC Propagation Tests
+
+    @Test
+    public void testMdcPropagationAcrossExecutor() throws InterruptedException {
+        // Set up MDC in main thread
+        String expectedRequestId = "test-request-123";
+        MDC.put("requestId", expectedRequestId);
+
+        // Create an executor wrapped with MDC awareness
+        Executor plainExecutor = Runnable::run; // Simple inline executor
+        Executor mdcAwareExecutor = ExecutorFactory.mdcAware(plainExecutor);
+
+        AtomicReference<String> capturedRequestId = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Execute task in wrapped executor
+        mdcAwareExecutor.execute(() -> {
+            // This should have the MDC context from the parent thread
+            capturedRequestId.set(MDC.get("requestId"));
+            latch.countDown();
+        });
+
+        latch.await(5, TimeUnit.SECONDS);
+
+        // Verify MDC was propagated
+        assertEquals(expectedRequestId, capturedRequestId.get(),
+                     "MDC context should propagate to executor task");
+    }
+
+    @Test
+    public void testMdcPropagationWithThreadPoolExecutor() throws Exception {
+        // Create a real thread pool executor
+        Executor plainExecutor = ExecutorFactory.newExecutor("TestMDC", 2, 10);
+        Executor mdcAwareExecutor = ExecutorFactory.mdcAware(plainExecutor);
+
+        String expectedRequestId = "thread-pool-test-456";
+        MDC.put("requestId", expectedRequestId);
+        MDC.put("userId", "test-user");
+
+        AtomicReference<String> capturedRequestId = new AtomicReference<>();
+        AtomicReference<String> capturedUserId = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Execute in thread pool
+        mdcAwareExecutor.execute(() -> {
+            capturedRequestId.set(MDC.get("requestId"));
+            capturedUserId.set(MDC.get("userId"));
+            latch.countDown();
+        });
+
+        latch.await(5, TimeUnit.SECONDS);
+
+        // Verify both MDC values propagated
+        assertEquals(expectedRequestId, capturedRequestId.get());
+        assertEquals("test-user", capturedUserId.get());
+    }
+
+    @Test
+    public void testMdcClearedWhenNull() throws InterruptedException {
+        // Don't set any MDC (context is empty/null)
+        var contextMap = MDC.getCopyOfContextMap();
+        assertTrue(contextMap == null || contextMap.isEmpty(),
+                   "MDC should start empty or null");
+
+        Executor plainExecutor = Runnable::run;
+        Executor mdcAwareExecutor = ExecutorFactory.mdcAware(plainExecutor);
+
+        AtomicReference<String> capturedRequestId = new AtomicReference<>("not-null");
+        CountDownLatch latch = new CountDownLatch(1);
+
+        mdcAwareExecutor.execute(() -> {
+            // MDC should be cleared (not inherit anything)
+            capturedRequestId.set(MDC.get("requestId"));
+            latch.countDown();
+        });
+
+        latch.await(5, TimeUnit.SECONDS);
+
+        // Verify MDC was cleared
+        assertNull(capturedRequestId.get(),
+                   "MDC should be cleared when parent context is null");
+    }
+
+    @Test
+    public void testMdcRestoresAfterExecution() throws InterruptedException {
+        // Set up initial MDC in executor thread
+        Executor plainExecutor = Runnable::run;
+        Executor mdcAwareExecutor = ExecutorFactory.mdcAware(plainExecutor);
+
+        String parentRequestId = "parent-request-789";
+        MDC.put("requestId", parentRequestId);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        mdcAwareExecutor.execute(() -> {
+            // Task sees parent MDC
+            assertEquals(parentRequestId, MDC.get("requestId"));
+
+            // Task modifies MDC
+            MDC.put("requestId", "modified-in-task");
+            MDC.put("taskSpecific", "task-value");
+
+            latch.countDown();
+        });
+
+        latch.await(5, TimeUnit.SECONDS);
+
+        // Verify original thread's MDC is unchanged
+        assertEquals(parentRequestId, MDC.get("requestId"),
+                     "Parent thread MDC should be unchanged");
+        assertNull(MDC.get("taskSpecific"),
+                   "Task-specific MDC should not leak to parent");
+    }
+
+    @Test
+    public void testMdcPropagationThroughCompletableFuture() throws Exception {
+        String expectedRequestId = "async-future-test-999";
+        MDC.put("requestId", expectedRequestId);
+
+        // Create MDC-aware executor
+        Executor mdcAwareExecutor = ExecutorFactory.mdcAware(ExecutorFactory.newExecutor("TestAsync"));
+
+        AtomicReference<String> capturedInFirstStage = new AtomicReference<>();
+        AtomicReference<String> capturedInSecondStage = new AtomicReference<>();
+
+        // Create async chain with MDC-aware executor
+        CompletableFuture<String> future = CompletableFuture
+                .supplyAsync(() -> {
+                    capturedInFirstStage.set(MDC.get("requestId"));
+                    return "first";
+                }, mdcAwareExecutor)
+                .thenApplyAsync(result -> {
+                    capturedInSecondStage.set(MDC.get("requestId"));
+                    return result + "-second";
+                }, mdcAwareExecutor);
+
+        future.get(5, TimeUnit.SECONDS);
+
+        // Verify MDC propagated through both stages
+        assertEquals(expectedRequestId, capturedInFirstStage.get(),
+                     "MDC should propagate to first async stage");
+        assertEquals(expectedRequestId, capturedInSecondStage.get(),
+                     "MDC should propagate to second async stage");
+    }
+
+    @Test
+    public void testMultipleContextValues() throws InterruptedException {
+        // Set multiple MDC values
+        MDC.put("requestId", "req-123");
+        MDC.put("userId", "user-456");
+        MDC.put("sessionId", "session-789");
+        MDC.put("correlationId", "corr-abc");
+
+        Executor mdcAwareExecutor = ExecutorFactory.mdcAware(ExecutorFactory.newExecutor("TestMulti"));
+
+        AtomicReference<String> reqId = new AtomicReference<>();
+        AtomicReference<String> userId = new AtomicReference<>();
+        AtomicReference<String> sessionId = new AtomicReference<>();
+        AtomicReference<String> corrId = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        mdcAwareExecutor.execute(() -> {
+            reqId.set(MDC.get("requestId"));
+            userId.set(MDC.get("userId"));
+            sessionId.set(MDC.get("sessionId"));
+            corrId.set(MDC.get("correlationId"));
+            latch.countDown();
+        });
+
+        latch.await(5, TimeUnit.SECONDS);
+
+        // Verify all MDC values propagated
+        assertEquals("req-123", reqId.get());
+        assertEquals("user-456", userId.get());
+        assertEquals("session-789", sessionId.get());
+        assertEquals("corr-abc", corrId.get());
     }
 }

--- a/frontend/src/composables/analysis-api-requester.ts
+++ b/frontend/src/composables/analysis-api-requester.ts
@@ -36,11 +36,11 @@ function byAxios(resolve: (req: Requester) => void) {
   resolve({
     request(namespace: string, api: string, target: string, parameters?: object): Promise<any> {
       const stepUpToken = useAnalysisStore().stepUpToken;
-      let headers = {};
+      let headers: any = {
+        'request-id': uuidv4()
+      };
       if (stepUpToken) {
-        headers = {
-          'net.netflix.stepup.authentication': stepUpToken,
-        };
+        headers['net.netflix.stepup.authentication'] = stepUpToken;
       }
       return axios
         .post('/jifa-api/analysis', {
@@ -57,7 +57,7 @@ function byAxios(resolve: (req: Requester) => void) {
 }
 
 function byStomp(resolve: (req: Requester) => void) {
-  const resRejMap = new Map<number, ResRej>();
+  const resRejMap = new Map<string, ResRej>();
 
   const client = new Client({
     brokerURL: `${'https:' === location.protocol ? 'wss' : 'ws'}://${location.host}/jifa-stomp`,
@@ -65,11 +65,6 @@ function byStomp(resolve: (req: Requester) => void) {
   });
 
   let subscriptionReceipt = uuidv4();
-  let requestId = 1;
-
-  function nextRequestId() {
-    return requestId++;
-  }
 
   client.connectHeaders = {};
   const token = useEnv().token;
@@ -86,7 +81,7 @@ function byStomp(resolve: (req: Requester) => void) {
     client.subscribe(
       '/ud/analysis',
       (message) => {
-        let requestId = Number(message.headers['request-id']);
+        let requestId = message.headers['request-id'];
 
         if (resRejMap.has(requestId)) {
           let resRej = resRejMap.get(requestId) as ResRej;
@@ -121,18 +116,13 @@ function byStomp(resolve: (req: Requester) => void) {
     client.watchForReceipt(subscriptionReceipt, () => {
       resolve({
         request(namespace: string, api: string, target: string, parameters?: object): Promise<any> {
-          let id = nextRequestId();
+          let id = uuidv4();
           const stepUpToken = useAnalysisStore().stepUpToken;
-          let headers;
+          let headers: any = {
+            'request-id': id
+          };
           if (stepUpToken) {
-            headers = {
-              'request-id': id.toString(),
-              'net.netflix.stepup.authentication': stepUpToken,
-            };
-          } else {
-            headers = {
-              'request-id': id.toString(),
-            };
+            headers['net.netflix.stepup.authentication'] = stepUpToken;
           }
 
           let params = {

--- a/frontend/src/composables/analysis-api-requester.ts
+++ b/frontend/src/composables/analysis-api-requester.ts
@@ -37,7 +37,7 @@ function byAxios(resolve: (req: Requester) => void) {
     request(namespace: string, api: string, target: string, parameters?: object): Promise<any> {
       const stepUpToken = useAnalysisStore().stepUpToken;
       let headers: any = {
-        'request-id': uuidv4()
+        'X-Request-ID': uuidv4()
       };
       if (stepUpToken) {
         headers['net.netflix.stepup.authentication'] = stepUpToken;

--- a/server/src/main/java/org/eclipse/jifa/server/controller/AnalysisApiHttpController.java
+++ b/server/src/main/java/org/eclipse/jifa/server/controller/AnalysisApiHttpController.java
@@ -19,6 +19,7 @@ import org.eclipse.jifa.server.ConfigurationAccessor;
 import org.eclipse.jifa.server.Constant;
 import org.eclipse.jifa.server.domain.dto.AnalysisApiRequest;
 import org.eclipse.jifa.server.service.AnalysisApiService;
+import org.slf4j.MDC;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.util.MimeTypeUtils;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -56,11 +58,22 @@ public class AnalysisApiHttpController extends ConfigurationAccessor {
             produces = Constant.APPLICATION_JSON)
     public Object handleRequest(@RequestHeader(name = HttpHeaders.CONTENT_TYPE) String contentType,
                                 @RequestHeader(name = Constant.HTTP_HEADER_ENABLE_SSE, required = false, defaultValue = "false") boolean enableSse,
+                                @RequestHeader(name = "X-Request-ID", required = false) String requestId,
                                 @RequestBody byte[] body) {
+        if (requestId == null || requestId.isEmpty()) {
+            requestId = UUID.randomUUID().toString();
+        }
 
-        JsonObject request = GSON.fromJson(new String(body, ofNullable(MimeTypeUtils.parseMimeType(contentType).getCharset()).orElse(Constant.CHARSET)),
-                                           JsonObject.class);
-        return postProcess(apiService.invoke(new AnalysisApiRequest(request)), enableSse);
+        MDC.put("requestId", requestId);
+        log.debug("Received HTTP analysis request: requestId={}", requestId);
+
+        try {
+            JsonObject request = GSON.fromJson(new String(body, ofNullable(MimeTypeUtils.parseMimeType(contentType).getCharset()).orElse(Constant.CHARSET)),
+                                            JsonObject.class);
+            return postProcess(apiService.invoke(new AnalysisApiRequest(request)), enableSse);
+        } finally {
+            MDC.remove("requestId");
+        }
     }
 
     private Object postProcess(CompletableFuture<?> future, boolean enableSse) {

--- a/server/src/main/java/org/eclipse/jifa/server/controller/AnalysisApiStompController.java
+++ b/server/src/main/java/org/eclipse/jifa/server/controller/AnalysisApiStompController.java
@@ -22,6 +22,7 @@ import org.eclipse.jifa.server.enums.Role;
 import org.eclipse.jifa.server.service.AnalysisApiService;
 import org.eclipse.jifa.server.service.impl.netflix.NetflixGandalfUserAccessService;
 import org.eclipse.jifa.server.util.ControllerUtil;
+import org.slf4j.MDC;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
@@ -41,6 +42,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 
 import com.netflix.infosec.stairmaster.enforcement.client.StepUpConstants;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.eclipse.jifa.server.Constant.STOMP_ANALYSIS_API_MAPPING;
@@ -64,34 +66,50 @@ public class AnalysisApiStompController {
     @SendToUser(destinations = STOMP_ANALYSIS_API_MAPPING, broadcast = false)
     public CompletableFuture<AnalysisApiStompResponseMessage>
     handleRequest(@Header(name = StompHeaders.CONTENT_TYPE, required = false, defaultValue = Constant.APPLICATION_JSON) String contentType,
-                  @Header(name = Constant.STOMP_ANALYSIS_API_REQUEST_ID_KEY, required = false, defaultValue = "") String requestId,
+                  @Header(name = Constant.STOMP_ANALYSIS_API_REQUEST_ID_KEY, required = false, defaultValue = "") String headerRequestId,
                   @Header(name = StepUpConstants.STEP_UP_AUTHENTICATION_HEADER_NAME, required = false) String stepUpToken,
                   Message<byte[]> message) {
-        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-        assert accessor != null;
-        Authentication auth = (Authentication) accessor.getUser();
-        SecurityContextHolder.getContext().setAuthentication(auth != null ? auth : ANONYMOUS);
-
-        log.info("handleRequest step up token: {}", stepUpToken);
-        if (stepUpToken != null) {
-            NetflixGandalfUserAccessService.STEP_UP_TOKEN.set(stepUpToken);
+        // Generate request ID if not provided
+        final String requestId;
+        if (headerRequestId == null || headerRequestId.isEmpty()) {
+            requestId = UUID.randomUUID().toString();
+        } else {
+            requestId = headerRequestId;
         }
- 
+
+        MDC.put("requestId", requestId);
+        log.debug("Received STOMP analysis request: requestId={}", requestId);
+
         try {
-            MimeType mimeType = ControllerUtil.checkMimeTypeForStompMessage(contentType);
-            CompletableFuture<AnalysisApiStompResponseMessage> responseMessage = new CompletableFuture<>();
-            apiService.invoke(new AnalysisApiRequest(ControllerUtil.parseArgs(mimeType, message.getPayload())))
-                      .whenComplete((r, t) -> {
-                          if (t == null) {
-                              responseMessage.complete(new AnalysisApiStompResponseMessage(requestId, r, null));
-                          } else {
-                              responseMessage.complete(new AnalysisApiStompResponseMessage(requestId, null, t));
-                          }
-                      });
-            return responseMessage;
+
+            StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+            assert accessor != null;
+            Authentication auth = (Authentication) accessor.getUser();
+            SecurityContextHolder.getContext().setAuthentication(auth != null ? auth : ANONYMOUS);
+
+            log.info("handleRequest step up token: {}", stepUpToken);
+            if (stepUpToken != null) {
+                NetflixGandalfUserAccessService.STEP_UP_TOKEN.set(stepUpToken);
+            }
+
+            try {
+                MimeType mimeType = ControllerUtil.checkMimeTypeForStompMessage(contentType);
+                CompletableFuture<AnalysisApiStompResponseMessage> responseMessage = new CompletableFuture<>();
+                apiService.invoke(new AnalysisApiRequest(ControllerUtil.parseArgs(mimeType, message.getPayload())))
+                        .whenComplete((r, t) -> {
+                            if (t == null) {
+                                responseMessage.complete(new AnalysisApiStompResponseMessage(requestId, r, null));
+                            } else {
+                                responseMessage.complete(new AnalysisApiStompResponseMessage(requestId, null, t));
+                            }
+                        });
+                return responseMessage;
+            } finally {
+                SecurityContextHolder.getContext().setAuthentication(null);
+                NetflixGandalfUserAccessService.STEP_UP_TOKEN.remove();
+            }
         } finally {
-            SecurityContextHolder.getContext().setAuthentication(null);
-            NetflixGandalfUserAccessService.STEP_UP_TOKEN.remove();
+            MDC.remove("requestId");
         }
     }
 

--- a/server/src/main/java/org/eclipse/jifa/server/service/impl/StorageServiceImpl.java
+++ b/server/src/main/java/org/eclipse/jifa/server/service/impl/StorageServiceImpl.java
@@ -123,7 +123,7 @@ public class StorageServiceImpl extends ConfigurationAccessor implements Storage
             }
         };
 
-        executor = ExecutorFactory.newExecutor("File Transfer");
+        executor = ExecutorFactory.mdcAware(ExecutorFactory.newExecutor("File Transfer"));
         available = true;
     }
 

--- a/server/src/main/java/org/eclipse/jifa/server/service/impl/netflix/ReadAheadService.java
+++ b/server/src/main/java/org/eclipse/jifa/server/service/impl/netflix/ReadAheadService.java
@@ -4,25 +4,25 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jifa.common.util.ExecutorFactory;
 
 @Component
 @Slf4j
 public class ReadAheadService {
     final static int CHUNK_SIZE = 8*1024*1024;
     final static int READ_THREADS = 16;
+    final static int READ_THREADS_QUEUE_CAPACITY = 16;
 
     final static int MAX_AGE_SECONDS = 300;
-    final static AtomicInteger threadCount = new AtomicInteger(0);
-    final ExecutorService readers = Executors.newFixedThreadPool(READ_THREADS, r -> new Thread(r, "ReadAheader-" + threadCount.getAndIncrement()));
+    final Executor readers = ExecutorFactory.mdcAware(ExecutorFactory.newExecutor("ReadAheader", READ_THREADS, READ_THREADS_QUEUE_CAPACITY));
 
     final ConcurrentMap<String, Instant> readAheadRequests = new ConcurrentHashMap<>();
 
@@ -68,25 +68,32 @@ public class ReadAheadService {
         String filename = file.toString();
         Instant existingRequest = readAheadRequests.get(filename);
         if (needsLoad(existingRequest)) {
+            // put before, so that nobody else attempts; small chance of a race here but meh
             readAheadRequests.put(filename, Instant.now());
             log.info("issueReadFile(): issuing for {}", filename);
-            readers.submit(() -> {
-                readAheadRequests.put(filename, Instant.now());
+            try {
+                readers.execute(() -> {
+                    readAheadRequests.put(filename, Instant.now());
 
-                log.info("issueReadFile(): issued for {}", filename);
-                try {
-                    byte[] chunk = new byte[CHUNK_SIZE];
-                    FileInputStream fis = new FileInputStream(filename);
-                    while(fis.read(chunk) > 0) {
-                        // read again
+                    log.info("issueReadFile(): issued for {}", filename);
+                    try (FileInputStream fis = new FileInputStream(filename)) {
+                        byte[] chunk = new byte[CHUNK_SIZE];
+                        while(fis.read(chunk) > 0) {
+                            // read again
+                        }
+                        log.info("issueReadFile(): completed for {}", filename);
+                    } catch (IOException e) {
+                        log.info("issueReadFile(): failed for {}, {}", filename, e);
                     }
-                    log.info("issueReadFile(): completed for {}", filename);
-                } catch (IOException e) {
-                    log.info("issueReadFile(): failed for {}, {}", filename, e);
-                }
 
-                readAheadRequests.put(filename, Instant.now());
-            });
+                    readAheadRequests.put(filename, Instant.now());
+                });
+            } catch (RejectedExecutionException e) {
+                log.warn("issueReadFile(): read-ahead queue full, abandoning read-ahead for {} (active threads: {}, queue capacity: {})",
+                    filename, READ_THREADS, READ_THREADS_QUEUE_CAPACITY);
+                // Remove the timestamp we just added since we're not actually processing this file
+                readAheadRequests.remove(filename);
+            }
         }
     }
 

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -48,8 +48,8 @@ logging:
     org.eclipse.jifa.server: DEBUG
     org.eclipse.jifa.analysis: DEBUG
   pattern:
-    console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{requestId:-}] %-5level %logger{36} - %msg%n"
-    file: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{requestId:-}] %-5level %logger{36} - %msg%n"
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [req=%X{requestId}] %-5level %logger{36} - %msg%n"
+    file: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [req=%X{requestId}] %-5level %logger{36} - %msg%n"
 
 netflix:
   sso:

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -45,6 +45,11 @@ server:
 logging:
   level:
     ROOT: DEBUG
+    org.eclipse.jifa.server: DEBUG
+    org.eclipse.jifa.analysis: DEBUG
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{requestId:-}] %-5level %logger{36} - %msg%n"
+    file: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{requestId:-}] %-5level %logger{36} - %msg%n"
 
 netflix:
   sso:

--- a/server/src/test/java/org/eclipse/jifa/server/controller/TestMdcRequestTracing.java
+++ b/server/src/test/java/org/eclipse/jifa/server/controller/TestMdcRequestTracing.java
@@ -1,0 +1,174 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.jifa.server.controller;
+
+import org.eclipse.jifa.server.Constant;
+import org.eclipse.jifa.server.service.AnalysisApiService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for MDC request tracing across HTTP requests and async operations
+ */
+@WebMvcTest(value = AnalysisApiHttpController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class})
+public class TestMdcRequestTracing {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private AnalysisApiService apiService;
+
+    private final AtomicReference<String> capturedRequestId = new AtomicReference<>();
+
+    @BeforeEach
+    public void before() {
+        capturedRequestId.set(null);
+
+        // Mock service that captures MDC requestId when invoked
+        Mockito.when(apiService.invoke(Mockito.any())).thenAnswer((Answer<CompletableFuture<?>>) invocation -> {
+            // Capture the requestId from MDC in the controller thread
+            String requestId = MDC.get("requestId");
+            capturedRequestId.set(requestId);
+            return CompletableFuture.completedFuture("Success");
+        });
+    }
+
+    @Test
+    public void testRequestIdGeneratedWhenNotProvided() throws Exception {
+        MvcResult result = mvc.perform(post(Constant.HTTP_API_PREFIX + Constant.HTTP_ANALYSIS_API_MAPPING)
+                                               .contentType(MediaType.APPLICATION_JSON)
+                                               .content("""
+                                                                {
+                                                                  "namespace": "test-namespace",
+                                                                  "api": "test-api",
+                                                                  "target": "test-target"
+                                                                }"""))
+                              .andExpect(request().asyncStarted())
+                              .andReturn();
+
+        mvc.perform(asyncDispatch(result))
+           .andExpect(status().isOk())
+           .andReturn();
+
+        // Verify that a request ID was automatically generated and set in MDC
+        assertNotNull(capturedRequestId.get(), "Request ID should be automatically generated");
+        // Verify it's a valid UUID format
+        UUID.fromString(capturedRequestId.get());
+    }
+
+    @Test
+    public void testRequestIdProvidedInHeader() throws Exception {
+        String expectedRequestId = "test-request-12345";
+
+        MvcResult result = mvc.perform(post(Constant.HTTP_API_PREFIX + Constant.HTTP_ANALYSIS_API_MAPPING)
+                                               .contentType(MediaType.APPLICATION_JSON)
+                                               .header("X-Request-ID", expectedRequestId)
+                                               .content("""
+                                                                {
+                                                                  "namespace": "test-namespace",
+                                                                  "api": "test-api",
+                                                                  "target": "test-target"
+                                                                }"""))
+                              .andExpect(request().asyncStarted())
+                              .andReturn();
+
+        mvc.perform(asyncDispatch(result))
+           .andExpect(status().isOk())
+           .andReturn();
+
+        // Verify that the provided request ID was used
+        assertEquals(expectedRequestId, capturedRequestId.get(),
+                     "Request ID from header should be used");
+    }
+
+    @Test
+    public void testRequestIdPropagatesWithSse() throws Exception {
+        String expectedRequestId = "sse-test-request-67890";
+
+        MvcResult result = mvc.perform(post(Constant.HTTP_API_PREFIX + Constant.HTTP_ANALYSIS_API_MAPPING)
+                                               .contentType(MediaType.APPLICATION_JSON)
+                                               .header("X-Request-ID", expectedRequestId)
+                                               .header(Constant.HTTP_HEADER_ENABLE_SSE, "true")
+                                               .content("""
+                                                                {
+                                                                  "namespace": "test-namespace",
+                                                                  "api": "test-api",
+                                                                  "target": "test-target"
+                                                                }"""))
+                              .andExpect(request().asyncStarted())
+                              .andReturn();
+
+        mvc.perform(asyncDispatch(result))
+           .andExpect(status().isOk())
+           .andReturn();
+
+        // Verify request ID propagates even with SSE enabled
+        assertEquals(expectedRequestId, capturedRequestId.get(),
+                     "Request ID should propagate with SSE enabled");
+    }
+
+    @Test
+    public void testMdcClearedAfterRequest() throws Exception {
+        // Set some MDC value before the test
+        MDC.put("testKey", "testValue");
+
+        String requestId = "cleanup-test-request";
+
+        MvcResult result = mvc.perform(post(Constant.HTTP_API_PREFIX + Constant.HTTP_ANALYSIS_API_MAPPING)
+                                               .contentType(MediaType.APPLICATION_JSON)
+                                               .header("X-Request-ID", requestId)
+                                               .content("""
+                                                                {
+                                                                  "namespace": "test-namespace",
+                                                                  "api": "test-api",
+                                                                  "target": "test-target"
+                                                                }"""))
+                              .andExpect(request().asyncStarted())
+                              .andReturn();
+
+        mvc.perform(asyncDispatch(result))
+           .andExpect(status().isOk())
+           .andReturn();
+
+        // Verify request ID was captured during request
+        assertEquals(requestId, capturedRequestId.get());
+
+        // MDC should still have our test key (not cleared by the test framework)
+        assertEquals("testValue", MDC.get("testKey"));
+
+        // Clean up
+        MDC.clear();
+    }
+}

--- a/server/src/test/java/org/eclipse/jifa/server/controller/TestMdcStompRequestTracing.java
+++ b/server/src/test/java/org/eclipse/jifa/server/controller/TestMdcStompRequestTracing.java
@@ -1,0 +1,180 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.jifa.server.controller;
+
+import com.google.gson.JsonElement;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jifa.server.Constant;
+import org.eclipse.jifa.server.service.AnalysisApiService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.slf4j.MDC;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.messaging.converter.GsonMessageConverter;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.util.MimeType;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT;
+
+/**
+ * Integration tests for MDC request tracing in STOMP/WebSocket requests
+ */
+@SuppressWarnings("NullableProblems")
+@Slf4j
+@SpringBootTest(webEnvironment = DEFINED_PORT)
+public class TestMdcStompRequestTracing {
+
+    @MockBean
+    private AnalysisApiService apiService;
+
+    private WebSocketStompClient webSocketStompClient;
+
+    private final AtomicReference<String> capturedRequestIdInService = new AtomicReference<>();
+
+    @BeforeEach
+    public void before() {
+        capturedRequestIdInService.set(null);
+
+        // Mock service that captures MDC requestId when invoked
+        Mockito.when(apiService.invoke(Mockito.any())).thenAnswer((Answer<CompletableFuture<?>>) invocation -> {
+            // Capture the requestId from MDC
+            String requestId = MDC.get("requestId");
+            capturedRequestIdInService.set(requestId);
+            log.info("Service invoked with requestId from MDC: {}", requestId);
+            return CompletableFuture.completedFuture("Hello Jifa");
+        });
+
+        this.webSocketStompClient = new WebSocketStompClient(new StandardWebSocketClient());
+        this.webSocketStompClient.setMessageConverter(new GsonMessageConverter());
+        this.webSocketStompClient.setTaskScheduler(new ConcurrentTaskScheduler());
+    }
+
+    @Test
+    public void testStompRequestIdPropagation() throws Exception {
+        StompSession session = webSocketStompClient
+                .connectAsync(String.format("ws://localhost:%d/%s", Constant.DEFAULT_PORT, Constant.STOMP_ENDPOINT),
+                              new StompSessionHandlerAdapter() {})
+                .get(10, TimeUnit.SECONDS);
+
+        CountDownLatch countDown = new CountDownLatch(1);
+
+        AtomicReference<String> requestIdInResponse = new AtomicReference<>();
+        session.subscribe(Constant.STOMP_USER_DESTINATION_PREFIX + "/" + Constant.STOMP_ANALYSIS_API_MAPPING,
+                          new StompSessionHandlerAdapter() {
+                              @Override
+                              public Type getPayloadType(StompHeaders headers) {
+                                  return JsonElement.class;
+                              }
+
+                              @Override
+                              public void handleFrame(StompHeaders headers, Object payload) {
+                                  requestIdInResponse.set(headers.getFirst(Constant.STOMP_ANALYSIS_API_REQUEST_ID_KEY));
+                                  countDown.countDown();
+                              }
+
+                              @Override
+                              public void handleTransportError(StompSession session, Throwable exception) {
+                                  log.error("Transport error", exception);
+                              }
+
+                              @Override
+                              public void handleException(StompSession session, StompCommand command,
+                                                          StompHeaders headers, byte[] payload, Throwable exception) {
+                                  log.error("STOMP error", exception);
+                              }
+                          });
+
+        // Send request with explicit request ID
+        String expectedRequestId = UUID.randomUUID().toString();
+        MimeType type = new MimeType("application", "json", StandardCharsets.UTF_8);
+        StompHeaders headers = new StompHeaders();
+        headers.setDestination(Constant.STOMP_APPLICATION_DESTINATION_PREFIX + "/" + Constant.STOMP_ANALYSIS_API_MAPPING);
+        headers.set(Constant.STOMP_ANALYSIS_API_REQUEST_ID_KEY, expectedRequestId);
+        headers.setContentType(type);
+        session.send(headers, Map.of("namespace", "test-namespace", "api", "test-api", "target", "test-target"));
+
+        // Wait for response
+        assertTrue(countDown.await(10, TimeUnit.SECONDS), "Should receive response within timeout");
+
+        // Verify request ID was returned in response
+        assertEquals(expectedRequestId, requestIdInResponse.get(),
+                     "Request ID should be returned in response");
+
+        // Verify request ID was set in MDC during service invocation
+        assertNotNull(capturedRequestIdInService.get(),
+                      "Request ID should have been set in MDC during service invocation");
+        assertEquals(expectedRequestId, capturedRequestIdInService.get(),
+                     "Request ID in MDC should match the one sent in STOMP headers");
+    }
+
+    @Test
+    public void testStompRequestIdGeneratedWhenNotProvided() throws Exception {
+        StompSession session = webSocketStompClient
+                .connectAsync(String.format("ws://localhost:%d/%s", Constant.DEFAULT_PORT, Constant.STOMP_ENDPOINT),
+                              new StompSessionHandlerAdapter() {})
+                .get(10, TimeUnit.SECONDS);
+
+        CountDownLatch countDown = new CountDownLatch(1);
+
+        AtomicReference<String> requestIdInResponse = new AtomicReference<>();
+        session.subscribe(Constant.STOMP_USER_DESTINATION_PREFIX + "/" + Constant.STOMP_ANALYSIS_API_MAPPING,
+                          new StompSessionHandlerAdapter() {
+                              @Override
+                              public Type getPayloadType(StompHeaders headers) {
+                                  return JsonElement.class;
+                              }
+
+                              @Override
+                              public void handleFrame(StompHeaders headers, Object payload) {
+                                  requestIdInResponse.set(headers.getFirst(Constant.STOMP_ANALYSIS_API_REQUEST_ID_KEY));
+                                  countDown.countDown();
+                              }
+                          });
+
+        // Send request WITHOUT request ID
+        MimeType type = new MimeType("application", "json", StandardCharsets.UTF_8);
+        StompHeaders headers = new StompHeaders();
+        headers.setDestination(Constant.STOMP_APPLICATION_DESTINATION_PREFIX + "/" + Constant.STOMP_ANALYSIS_API_MAPPING);
+        headers.setContentType(type);
+        session.send(headers, Map.of("namespace", "test-namespace", "api", "test-api", "target", "test-target"));
+
+        // Wait for response
+        assertTrue(countDown.await(10, TimeUnit.SECONDS), "Should receive response within timeout");
+
+        // Verify a request ID was generated (even if empty string is returned, MDC should have been set)
+        // Note: Based on the controller code, it defaults to empty string if not provided
+        assertNotNull(capturedRequestIdInService.get(),
+                      "Request ID should have been generated and set in MDC");
+    }
+}


### PR DESCRIPTION
Log entries have a new `[req=xxxx]` with a uuid. Client provides it, but if the client does not then the server will generate its own.

```
2025-11-18 05:40:15.297 [SBN @DefaultExecutor - 1] [req=e3eccd2a-b139-481b-bcd1-97659694b70d] DEBUG org.eclipse.jifa.server.controller.AnalysisApiStompController - Received STOMP analysis request: requestId=e3eccd2a-b139-481b-bcd1-97659694b70d
2025-11-18 05:40:15.297 [SBN @DefaultExecutor - 1] [req=e3eccd2a-b139-481b-bcd1-97659694b70d] INFO  org.eclipse.jifa.server.controller.AnalysisApiStompController - handleRequest step up token: null
2025-11-18 05:40:15.298 [SBN @DefaultExecutor - 1] [req=e3eccd2a-b139-481b-bcd1-97659694b70d] INFO  org.eclipse.jifa.server.service.impl.netflix.PathLookupServiceImpl - Path lookup (Netflix) for <<redacted>> of type HEAP_DUMP resolved to <<redacted>>
```